### PR TITLE
fix: explictly set schema for reading bed via polars csv

### DIFF
--- a/workflow/scripts/cov.py
+++ b/workflow/scripts/cov.py
@@ -53,6 +53,7 @@ def polars_read():
             has_header=False,
             new_columns=["chr", "start", "end", "coverage"],
             low_memory=True,
+            schema_overrides=[pl.Utf8, pl.Int64, pl.Int64, pl.Int64],
         )
         .lazy()
         .filter(pl.col("coverage") > 0)


### PR DESCRIPTION
in genomes with mixed purely numeric (1,2,3..) and alphanumeric (chr1..) polars may infer that the first column of the bed (chrom) is only numeric, leading to failure to parse alphanumeric chroms at the end.

Fixes #52