### PR TITLE
fix: exclude_from_shuffle when no excludes are configured

### DIFF
--- a/workflow/rules/coverages.smk
+++ b/workflow/rules/coverages.smk
@@ -126,13 +126,14 @@ rule exclude_from_shuffle:
     conda:
         DEFAULT_ENV
     params:
-        exclude=EXCLUDES,
+        exclude=lambda wc: " ".join(EXCLUDES) if EXCLUDES else "",
     shell:
         """
-
-        ( \
-            bedtools genomecov -bga -i {input.filtered} -g {input.fai} | awk '$4 == 0'; \
-            less {params.exclude} \
+        (
+            bedtools genomecov -bga -i {input.filtered} -g {input.fai} | awk '$4 == 0'
+            if [ -n "{params.exclude}" ]; then
+                gunzip -cf {params.exclude}
+            fi
         ) \
             | cut -f 1-3 \
             | bedtools sort \


### PR DESCRIPTION
Split out of #62. Guards the empty-`EXCLUDES` case (non-hg38 references) so `exclude_from_shuffle` no longer fails, and replaces `less` with `gunzip -cf` for portable handling of mixed plain/gzip/bgzip inputs on macOS and Linux.
