### PR TITLE
feat: default min_frac_accessible to 0.10

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -57,9 +57,9 @@ Forgo the use of FDR peak calling and instead call peaks for regions with at lea
 ```
 min_per_acc_peak = 0.25
 ```
-Apply a percent actuation filter on top of the FDR peak calling. Default is `0.0` for no filter.
+Apply a percent actuation filter on top of the FDR peak calling. Default is `0.10`; set to `0.0` for no filter.
 ```
-min_frac_accessible: 0.0
+min_frac_accessible: 0.10
 ```
 Process only chromosomes matching this regular expression:
 ```

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -56,7 +56,7 @@ if MIN_PER_ACC_PEAK is None:
     MIN_PER_ACC_PEAK = 0.0
 else:
     MAX_PEAK_FDR = 1.0
-MIN_FRAC_ACCESSIBLE = config.get("min_frac_accessible", 0)
+MIN_FRAC_ACCESSIBLE = config.get("min_frac_accessible", 0.10)
 
 # data filtering
 FILTER_FLAG = config.get("samtools-filter-flag", "260")  # 2308


### PR DESCRIPTION
Split out of #62. FIRE peaks must now have at least 10% of reads accessible (`fire_coverage/coverage >= 0.10`, applied in `merge_fire_peaks.py`) in addition to passing FDR peak calling. Set `min_frac_accessible: 0.0` to restore the old behavior.

On the test dataset this removes no peaks (all peaks there exceed 19% accessibility), so test outputs are unchanged; on real WGS data marginal peaks will be filtered.
