### PR TITLE
ci: pixi test-task improvements, setup-pixi v0.9.6, ruff formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: v0.70.2
           cache: true

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,37 +1,16 @@
 [workspace]
 authors = ["Mitchell Robert Vollger <mrvollger@gmail.com>"]
 channels = ["conda-forge", "bioconda"]
-description = "Add a short description here"
+description = "A Snakemake pipeline for calling FIRE peaks using fibertools-rs."
 name = "FIRE"
 platforms = ["osx-64", "linux-64"]
 version = "0.1.2"
 
 [tasks]
 fmt = "ruff format . && taplo format pixi.toml && snakefmt workflow/"
-test-data = { cmd = [
-  "cd",
-  "$INIT_CWD",
-  "&&",
-  "mkdir",
-  "-p",
-  "fire-test-data",
-  "&&",
-  "rclone",
-  "sync",
-  ":s3,env_auth=false,provider=Other,endpoint=s3.kopah.orci.washington.edu:stergachis/public/FIRE/test-data",
-  "fire-test-data/",
-] }
-test = { cmd = [
-  "cd",
-  "$INIT_CWD/fire-test-data",
-  "&&",
-  "snakemake",
-  "-s",
-  "$PIXI_PROJECT_ROOT/workflow/Snakefile",
-  "--configfile",
-  "test.yaml",
-  "-k",
-], depends-on = [
+test-data = { cmd = '''bash -c 'if [ -f "$INIT_CWD/fire-test-data/test.cram" ]; then echo "test data already present, skipping download"; else mkdir -p "$INIT_CWD/fire-test-data" && rclone sync ":s3,env_auth=false,provider=Other,endpoint=s3.kopah.orci.washington.edu:stergachis/public/FIRE/test-data" "$INIT_CWD/fire-test-data/"; fi' ''' }
+test-clean = { cmd = '''bash -c 'cd "$INIT_CWD/fire-test-data" && rm -rf results temp .snakemake' ''' }
+test = { cmd = '''bash -c 'cd "$INIT_CWD/fire-test-data" && rm -rf results temp && snakemake -s "$PIXI_PROJECT_ROOT/workflow/Snakefile" --configfile test.yaml -k' ''', depends-on = [
   "test-data",
 ], clean-env = true }
 fire = { cmd = [

--- a/workflow/scripts/fdr-table.py
+++ b/workflow/scripts/fdr-table.py
@@ -59,7 +59,7 @@ def read_pileup_file(infile, nrows):
     # add scema overrides for the score columns
     # Build schema overrides keyed by positional column names (column_1, column_2, ...)
     # because polars infers schema BEFORE new_columns is applied when has_header=False.
-    # Keying on '#chrom' / 'score' here would be silently ignored. 
+    # Keying on '#chrom' / 'score' here would be silently ignored.
     schema_overrides = {}
     for col_idx, col_name in enumerate(header, start=1):
         positional = f"column_{col_idx}"

--- a/workflow/scripts/merge_fire_peaks.py
+++ b/workflow/scripts/merge_fire_peaks.py
@@ -124,7 +124,12 @@ def main(
     logger.setLevel(log_level)
 
     inf = io.StringIO(sys.stdin.read())
-    df = pl.read_csv(inf, separator="\t", null_values=".", schema_overrides={"#chrom": pl.Utf8},)
+    df = pl.read_csv(
+        inf,
+        separator="\t",
+        null_values=".",
+        schema_overrides={"#chrom": pl.Utf8},
+    )
     if df.shape[0] == 0:
         logging.info("No peaks to merge")
         return 0


### PR DESCRIPTION
Split out of #62.

- `pixi run test-data` skips the download when `fire-test-data/test.cram` already exists
- new `test-clean` task wipes `results`, `temp`, and `.snakemake`
- `test` starts from a clean `results`/`temp` state
- fills in the pixi `description`
- `setup-pixi` action v0.8.1 → v0.9.6
- ruff-only formatting in `fdr-table.py` and `merge_fire_peaks.py`

No version or platform changes here — those stay in #62.
